### PR TITLE
Add helper method for entity queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ world.each_entity(Health, Enemy) do |entity_id, health|
 end
 ```
 
+To find just the first matching entity, use `first_entity`:
+
+```ruby
+# Returns [entity_id, component1, component2, ...] or nil if no match
+result = world.first_entity(Position, Velocity)
+if result
+  entity_id, pos, vel = result
+  puts "Found entity #{entity_id} at position (#{pos.x}, #{pos.y})"
+end
+
+# Or use with a block
+world.first_entity(Player, Health) do |entity_id, player, health|
+  puts "Player health: #{health.current}/#{health.max}"
+end
+```
+
 ### Destroying Entities
 
 ```ruby

--- a/lib/drecs.rb
+++ b/lib/drecs.rb
@@ -351,6 +351,28 @@ module Drecs
       end
     end
 
+    # Finds the first entity that has the specified components.
+    # Returns [entity_id, component1, component2, ...] or nil if no match found.
+    # If a block is given, yields the entity_id and components, returning the entity_id.
+    def first_entity(*component_classes, &block)
+      query(*component_classes) do |entity_ids, *stores|
+        next if entity_ids.empty?
+
+        entity_id = entity_ids[0]
+        components = stores.map { |store| store[0] }
+
+        if block_given?
+          yield(entity_id, *components)
+          return entity_id
+        else
+          return [entity_id, *components]
+        end
+      end
+
+      # No matching entity found
+      nil
+    end
+
     # Removes components from a passed query
     # This is safe to use during iteration since it collects entities first.
     def remove_components_from_query(query, *components)

--- a/tests/test_first_entity.rb
+++ b/tests/test_first_entity.rb
@@ -1,0 +1,57 @@
+def test_first_entity_with_results args, assert
+  world = Drecs::World.new
+
+  entity1 = world.spawn({ position: { x: 10, y: 20 }, velocity: { dx: 1, dy: 2 } })
+  entity2 = world.spawn({ position: { x: 5, y: 15 }, velocity: { dx: 3, dy: 4 } })
+
+  result = world.first_entity(:position, :velocity)
+
+  assert.true! result != nil, "Expected first_entity to return a result"
+  assert.equal! result.length, 3, "Expected [entity_id, position, velocity]"
+
+  entity_id, position, velocity = result
+  assert.true! [entity1, entity2].include?(entity_id), "Expected entity_id to be one of the spawned entities"
+  assert.true! position.is_a?(Hash), "Expected position to be a hash"
+  assert.true! velocity.is_a?(Hash), "Expected velocity to be a hash"
+end
+
+def test_first_entity_with_block args, assert
+  world = Drecs::World.new
+
+  entity1 = world.spawn({ position: { x: 10, y: 20 }, velocity: { dx: 1, dy: 2 } })
+  entity2 = world.spawn({ position: { x: 5, y: 15 }, velocity: { dx: 3, dy: 4 } })
+
+  yielded_entity_id = nil
+  yielded_position = nil
+  yielded_velocity = nil
+
+  returned_id = world.first_entity(:position, :velocity) do |entity_id, position, velocity|
+    yielded_entity_id = entity_id
+    yielded_position = position
+    yielded_velocity = velocity
+  end
+
+  assert.true! yielded_entity_id != nil, "Expected block to be called"
+  assert.true! [entity1, entity2].include?(yielded_entity_id), "Expected entity_id to be one of the spawned entities"
+  assert.equal! returned_id, yielded_entity_id, "Expected method to return the entity_id when block given"
+  assert.true! yielded_position.is_a?(Hash), "Expected position to be a hash"
+  assert.true! yielded_velocity.is_a?(Hash), "Expected velocity to be a hash"
+end
+
+def test_first_entity_no_match args, assert
+  world = Drecs::World.new
+
+  entity1 = world.spawn({ position: { x: 10, y: 20 } })
+
+  result = world.first_entity(:position, :velocity)
+
+  assert.equal! result, nil, "Expected nil when no entities match"
+end
+
+def test_first_entity_empty_world args, assert
+  world = Drecs::World.new
+
+  result = world.first_entity(:position)
+
+  assert.equal! result, nil, "Expected nil for empty world"
+end


### PR DESCRIPTION
Adds a new first_entity method to the World class that returns the first entity and its components matching a query. This is useful when you only need to find a single entity rather than iterating over all matches.

The method supports both block and non-block forms:
- Without block: returns [entity_id, component1, component2, ...] or nil
- With block: yields entity_id and components, returns entity_id or nil

Changes:
- Add first_entity method to World class (lib/drecs.rb:354-374)
- Add comprehensive test suite (tests/test_first_entity.rb)
- Update README with usage examples and documentation